### PR TITLE
Using next-tina helper packages, upgrading Tina

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"moment": "^2.24.0",
 		"next": "^9.0.6",
 		"next-tinacms-json": "^0.3.5",
+		"next-tinacms-markdown": "^0.2.5",
 		"prop-types": "^15.7.2",
 		"raw-loader": "^3.0.0",
 		"react": "^16.8.6",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"react-dom": "^16.8.6",
 		"react-markdown": "^4.1.0",
 		"styled-components": "^4.4.1",
-		"tinacms": "^0.13.0",
+		"tinacms": "^0.16.0",
 		"typescript": "^3.7.2",
 		"webpack": "^4.37.0"
 	},

--- a/package.json
+++ b/package.json
@@ -1,50 +1,51 @@
 {
-  "name": "foresry-starter-blog-next",
-  "private": true,
-  "description": "A simple starter to get up and developing quickly with TinaCMS & Next",
-  "license": "MIT",
-  "version": "0.1.0",
-  "author": "@kendallstraut",
-  "scripts": {
-    "dev-next": "next src",
-    "dev": "node server.js",
-    "develop": "yarn dev",
-    "build": "next build src",
-    "start-next": "next start src",
-    "start": "cross-env NODE_ENV=production node server.js",
-    "export": "next export src",
-    "deploy": "yarn build && yarn export",
-    "forestry-preview": "next src -p 8080 -H 0.0.0.0"
-  },
-  "dependencies": {
-    "@tinacms/api-git": "^0.4.6",
-    "@tinacms/git-client": "^0.4.1",
-    "cors": "^2.8.5",
-    "dotenv": "^8.2.0",
-    "express": "^4.17.1",
-    "glob": "^7.1.6",
-    "gray-matter": "^4.0.2",
-    "moment": "^2.24.0",
-    "next": "^9.0.6",
-    "prop-types": "^15.7.2",
-    "raw-loader": "^3.0.0",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
-    "react-markdown": "^4.1.0",
-    "styled-components": "^4.4.1",
-    "tinacms": "^0.10.0",
-    "typescript": "^3.7.2",
-    "webpack": "^4.37.0"
-  },
-  "devDependencies": {
-    "prettier": "^1.18.2"
-  },
-  "keywords": [
-    "next",
-    "tinacms"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/kendallstrautman/brevifolia-next-tinacms"
-  }
+	"name": "foresry-starter-blog-next",
+	"private": true,
+	"description": "A simple starter to get up and developing quickly with TinaCMS & Next",
+	"license": "MIT",
+	"version": "0.1.0",
+	"author": "@kendallstraut",
+	"scripts": {
+		"dev-next": "next src",
+		"dev": "node server.js",
+		"develop": "yarn dev",
+		"build": "next build src",
+		"start-next": "next start src",
+		"start": "cross-env NODE_ENV=production node server.js",
+		"export": "next export src",
+		"deploy": "yarn build && yarn export",
+		"forestry-preview": "next src -p 8080 -H 0.0.0.0"
+	},
+	"dependencies": {
+		"@tinacms/api-git": "^0.4.6",
+		"@tinacms/git-client": "^0.4.1",
+		"cors": "^2.8.5",
+		"dotenv": "^8.2.0",
+		"express": "^4.17.1",
+		"glob": "^7.1.6",
+		"gray-matter": "^4.0.2",
+		"moment": "^2.24.0",
+		"next": "^9.0.6",
+		"next-tinacms-json": "^0.3.5",
+		"prop-types": "^15.7.2",
+		"raw-loader": "^3.0.0",
+		"react": "^16.8.6",
+		"react-dom": "^16.8.6",
+		"react-markdown": "^4.1.0",
+		"styled-components": "^4.4.1",
+		"tinacms": "^0.13.0",
+		"typescript": "^3.7.2",
+		"webpack": "^4.37.0"
+	},
+	"devDependencies": {
+		"prettier": "^1.18.2"
+	},
+	"keywords": [
+		"next",
+		"tinacms"
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/kendallstrautman/brevifolia-next-tinacms"
+	}
 }

--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -4,24 +4,24 @@ import { Tina, TinaCMS } from 'tinacms'
 import { GitClient } from '@tinacms/git-client'
 
 class MyApp extends App {
-  constructor() {
-    super()
-    this.cms = new TinaCMS()
-    const client = new GitClient('http://localhost:3000/___tina')
-    this.cms.registerApi('git', client)
-  }
-  options = {
-      sidebar: {
-        hidden: process.env.NODE_ENV === "production"
-      }
-  }
-  render() {
-    const { Component, pageProps } = this.props
-    return (
-      <Tina cms={this.cms} {...this.options.sidebar}>
-        <Component {...pageProps} />
-      </Tina>
-    )
-  }
+	constructor() {
+		super()
+		this.cms = new TinaCMS({
+			sidebar: {
+				hidden: process.env.NODE_ENV === 'production'
+			}
+		})
+		const client = new GitClient('http://localhost:3000/___tina')
+		this.cms.registerApi('git', client)
+	}
+
+	render() {
+		const { Component, pageProps } = this.props
+		return (
+			<Tina cms={this.cms}>
+				<Component {...pageProps} />
+			</Tina>
+		)
+	}
 }
 export default MyApp

--- a/src/pages/blog/[slug].js
+++ b/src/pages/blog/[slug].js
@@ -214,7 +214,7 @@ BlogTemplate.getInitialProps = async function(ctx) {
 		markdownFile: {
 			fileRelativePath: `src/posts/${slug}.md`,
 			frontmatter: data.data,
-			markdownBody: data.markdownFile
+			markdownBody: data.content
 		},
 		title: config.default.title
 	}

--- a/src/pages/blog/[slug].js
+++ b/src/pages/blog/[slug].js
@@ -1,261 +1,256 @@
 import * as React from 'react'
-import matter from "gray-matter";
-import ReactMarkdown from "react-markdown";
+import matter from 'gray-matter'
+import ReactMarkdown from 'react-markdown'
 import { useCMS, useLocalForm, useWatchFormValues } from 'tinacms'
 
 import Layout from '../../components/Layout'
 import toMarkdownString from '../../utils/toMarkdownString'
 
 export default function BlogTemplate(props) {
+	// TINA CMS Config ---------------------------
+	const cms = useCMS()
+	const [post, form] = useLocalForm({
+		id: props.fileRelativePath, // needs to be unique
+		label: 'Edit Post',
 
-  // TINA CMS Config ---------------------------
-  const cms = useCMS()
-  const [post, form] = useLocalForm({
-    id: props.fileRelativePath, // needs to be unique
-    label: 'Edit Post',
+		// starting values for the post object
+		initialValues: {
+			fileRelativePath: props.fileRelativePath,
+			frontmatter: props.data,
+			markdownBody: props.content
+		},
 
-    // starting values for the post object
-    initialValues: {
-      fileRelativePath: props.fileRelativePath,
-      frontmatter: props.data,
-      markdownBody: props.content
-    },
+		// field definition
+		fields: [
+			{
+				label: 'Hero Image',
+				name: 'frontmatter.hero_image',
+				component: 'image',
+				// Generate the frontmatter value based on the filename
+				parse: filename => `../static/${filename}`,
 
-    // field definition
-    fields: [
-      {
-        label: "Hero Image",
-        name: 'frontmatter.hero_image',
-        component: "image",
-        // Generate the frontmatter value based on the filename
-        parse: filename => `../static/${filename}`,
-  
-        // Decide the file upload directory for the post
-        uploadDir: () => "/src/static/",
-  
-        // Generate the src attribute for the preview image.
-        previewSrc: data => `/static/${data.frontmatter.hero_image}`,
-      },
-      {
-        name: 'frontmatter.title',
-        label: 'Title',
-        component: 'text',
-      },
-      {
-        name: 'frontmatter.date',
-        label: 'Date',
-        component: 'date',
-      },
-      {
-        name: 'frontmatter.author',
-        label: 'Author',
-        component: 'text',
-      },
-      {
-        name: 'markdownBody',
-        label: 'Blog Body',
-        component: 'markdown',
-      },
-      
-    ],
+				// Decide the file upload directory for the post
+				uploadDir: () => '/src/public/static/',
 
-    // save & commit the file when the "save" button is pressed
-    onSubmit(data) {
-      return cms.api.git
-        .writeToDisk({
-          fileRelativePath: props.fileRelativePath,
-          content: toMarkdownString(formState.values),
-        })
-        .then(() => {
-          return cms.api.git.commit({
-            files: [props.fileRelativePath],
-            message: `Commit from Tina: Update ${data.fileRelativePath}`,
-          })
-        })
-    },
-  })
+				// Generate the src attribute for the preview image.
+				previewSrc: data => `/static/${data.frontmatter.hero_image}`
+			},
+			{
+				name: 'frontmatter.title',
+				label: 'Title',
+				component: 'text'
+			},
+			{
+				name: 'frontmatter.date',
+				label: 'Date',
+				component: 'date'
+			},
+			{
+				name: 'frontmatter.author',
+				label: 'Author',
+				component: 'text'
+			},
+			{
+				name: 'markdownBody',
+				label: 'Blog Body',
+				component: 'markdown'
+			}
+		],
 
-  const writeToDisk = React.useCallback(formState => {
-    cms.api.git.onChange({
-      fileRelativePath: props.fileRelativePath,
-      content: toMarkdownString(formState.values),
-    })
-  }, [])
+		// save & commit the file when the "save" button is pressed
+		onSubmit(data) {
+			return cms.api.git
+				.writeToDisk({
+					fileRelativePath: props.fileRelativePath,
+					content: toMarkdownString(formState.values)
+				})
+				.then(() => {
+					return cms.api.git.commit({
+						files: [props.fileRelativePath],
+						message: `Commit from Tina: Update ${data.fileRelativePath}`
+					})
+				})
+		}
+	})
 
-  useWatchFormValues(form, writeToDisk)
+	const writeToDisk = React.useCallback(formState => {
+		cms.api.git.onChange({
+			fileRelativePath: props.fileRelativePath,
+			content: toMarkdownString(formState.values)
+		})
+	}, [])
 
-// END Tina CMS config -----------------------------
+	useWatchFormValues(form, writeToDisk)
 
-  function reformatDate(fullDate) {
-    const date = new Date(fullDate)
-    return date.toDateString().slice(4);
-  }
+	// END Tina CMS config -----------------------------
 
-  return (
-    <Layout siteTitle={props.title}>
-      <article className="blog">
-          <figure className="blog__hero">
-          <img
-              src={post.frontmatter.hero_image}
-              alt={`blog_hero_${post.frontmatter.title}`}
-          />
-          </figure>
-          <div className="blog__info">
-          <h1>{post.frontmatter.title}</h1>
-          <h3>{reformatDate(post.frontmatter.date)}</h3>
-          </div>
-          <div className="blog__body">
-          <ReactMarkdown source={post.markdownBody} />
-          </div>
-          <h2 className="blog__footer">
-          Written By: {post.frontmatter.author}
-          </h2>
-      </article>
-      <style jsx>
-        {`
-          .blog h1 {
-            margin-bottom: .7rem;
-          }
-          
-          .blog__hero {
-            min-height: 300px;
-            height: 60vh;
-            width: 100%;
-            margin: 0;
-            overflow: hidden;
-          }
-          .blog__hero img {
-            margin-bottom: 0;
-            object-fit: cover;
-            min-height: 100%;
-            min-width: 100%;
-            object-position: center;
-          }
-          
-          .blog__info {
-            padding: 1.5rem 1.25rem;
-            width: 100%;
-            max-width: 768px;
-            margin: 0 auto;
-          }
-          .blog__info h1 {
-            margin-bottom: 0.66rem;
-          }
-          .blog__info h3 {
-            margin-bottom: 0;
-          }
-          
-          .blog__body {
-            width: 100%;
-            padding: 0 1.25rem;
-            margin: 0 auto;
-            display: flex;
-            flex-direction: column;
-            justify-content: center;
-          }
-          .blog__body a {
-            padding-bottom: 1.5rem;
-          }
-          .blog__body:last-child {
-            margin-bottom: 0;
-          }
-          .blog__body h1 h2 h3 h4 h5 h6 p {
-            font-weight: normal;
-          }
-          .blog__body p {
-            color: inherit;
-          }
-          .blog__body ul {
-            list-style: initial;
-          }
-          .blog__body ul ol {
-            margin-left: 1.25rem;
-            margin-bottom: 1.25rem;
-            padding-left: 1.45rem;
-          }
-          
-          .blog__footer {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            padding: 1.5rem 1.25rem;
-            width: 100%;
-            max-width: 800px;
-            margin: 0 auto;
-          }
-          .blog__footer h2 {
-            margin-bottom: 0;
-          }
-          .blog__footer a {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-          }
-          .blog__footer a svg {
-            width: 20px;
-          }
-          
-          @media (min-width: 768px) {
-            .blog {
-              display: flex;
-              flex-direction: column;
-            }
-            .blog__body {
-              max-width: 800px;
-              padding: 0 2rem;
-            }
-            .blog__body span {
-              width: 100%;
-              margin: 1.5rem auto;
-            }
-            .blog__body ul ol {
-              margin-left: 1.5rem;
-              margin-bottom: 1.5rem;
-            }
-            .blog__hero {
-              min-height: 600px;
-              height: 75vh;
-            }
-            .blog__info {
-              text-align: center;
-              padding: 2rem 0;
-            }
-            .blog__info h1 {
-              max-width: 500px;
-              margin: 0 auto 0.66rem auto;
-            }
-            .blog__footer {
-              padding: 2.25rem;
-            }
-          }
-          
-          @media (min-width: 1440px) {
-            .blog__hero {
-              height: 70vh;
-            }
-            .blog__info {
-              padding: 3rem 0;
-            }
-            .blog__footer {
-              padding: 2rem 2rem 3rem 2rem;
-            }
-          }
-        `}
-        
-      </style>
-    </Layout>
-    );
+	function reformatDate(fullDate) {
+		const date = new Date(fullDate)
+		return date.toDateString().slice(4)
+	}
+
+	return (
+		<Layout siteTitle={props.title}>
+			<article className='blog'>
+				<figure className='blog__hero'>
+					<img
+						src={post.frontmatter.hero_image}
+						alt={`blog_hero_${post.frontmatter.title}`}
+					/>
+				</figure>
+				<div className='blog__info'>
+					<h1>{post.frontmatter.title}</h1>
+					<h3>{reformatDate(post.frontmatter.date)}</h3>
+				</div>
+				<div className='blog__body'>
+					<ReactMarkdown source={post.markdownBody} />
+				</div>
+				<h2 className='blog__footer'>Written By: {post.frontmatter.author}</h2>
+			</article>
+			<style jsx>
+				{`
+					.blog h1 {
+						margin-bottom: 0.7rem;
+					}
+
+					.blog__hero {
+						min-height: 300px;
+						height: 60vh;
+						width: 100%;
+						margin: 0;
+						overflow: hidden;
+					}
+					.blog__hero img {
+						margin-bottom: 0;
+						object-fit: cover;
+						min-height: 100%;
+						min-width: 100%;
+						object-position: center;
+					}
+
+					.blog__info {
+						padding: 1.5rem 1.25rem;
+						width: 100%;
+						max-width: 768px;
+						margin: 0 auto;
+					}
+					.blog__info h1 {
+						margin-bottom: 0.66rem;
+					}
+					.blog__info h3 {
+						margin-bottom: 0;
+					}
+
+					.blog__body {
+						width: 100%;
+						padding: 0 1.25rem;
+						margin: 0 auto;
+						display: flex;
+						flex-direction: column;
+						justify-content: center;
+					}
+					.blog__body a {
+						padding-bottom: 1.5rem;
+					}
+					.blog__body:last-child {
+						margin-bottom: 0;
+					}
+					.blog__body h1 h2 h3 h4 h5 h6 p {
+						font-weight: normal;
+					}
+					.blog__body p {
+						color: inherit;
+					}
+					.blog__body ul {
+						list-style: initial;
+					}
+					.blog__body ul ol {
+						margin-left: 1.25rem;
+						margin-bottom: 1.25rem;
+						padding-left: 1.45rem;
+					}
+
+					.blog__footer {
+						display: flex;
+						justify-content: space-between;
+						align-items: center;
+						padding: 1.5rem 1.25rem;
+						width: 100%;
+						max-width: 800px;
+						margin: 0 auto;
+					}
+					.blog__footer h2 {
+						margin-bottom: 0;
+					}
+					.blog__footer a {
+						display: flex;
+						justify-content: space-between;
+						align-items: center;
+					}
+					.blog__footer a svg {
+						width: 20px;
+					}
+
+					@media (min-width: 768px) {
+						.blog {
+							display: flex;
+							flex-direction: column;
+						}
+						.blog__body {
+							max-width: 800px;
+							padding: 0 2rem;
+						}
+						.blog__body span {
+							width: 100%;
+							margin: 1.5rem auto;
+						}
+						.blog__body ul ol {
+							margin-left: 1.5rem;
+							margin-bottom: 1.5rem;
+						}
+						.blog__hero {
+							min-height: 600px;
+							height: 75vh;
+						}
+						.blog__info {
+							text-align: center;
+							padding: 2rem 0;
+						}
+						.blog__info h1 {
+							max-width: 500px;
+							margin: 0 auto 0.66rem auto;
+						}
+						.blog__footer {
+							padding: 2.25rem;
+						}
+					}
+
+					@media (min-width: 1440px) {
+						.blog__hero {
+							height: 70vh;
+						}
+						.blog__info {
+							padding: 3rem 0;
+						}
+						.blog__footer {
+							padding: 2rem 2rem 3rem 2rem;
+						}
+					}
+				`}
+			</style>
+		</Layout>
+	)
 }
 
 BlogTemplate.getInitialProps = async function(ctx) {
-  const { slug } = ctx.query
-  const content = await import(`../../posts/${slug}.md`)
-  const config = await import(`../../data/config.json`)
-  const data = matter(content.default);
+	const { slug } = ctx.query
+	const content = await import(`../../posts/${slug}.md`)
+	const config = await import(`../../data/config.json`)
+	const data = matter(content.default)
 
-  return {
-    fileRelativePath: `src/posts/${slug}.md`,
-    title: config.title,
-    ...data
-  }
+	return {
+		fileRelativePath: `src/posts/${slug}.md`,
+		title: config.title,
+		...data
+	}
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,108 +1,76 @@
-import { useCMS, useLocalForm, useWatchFormValues } from 'tinacms'
 import matter from 'gray-matter'
+import { useLocalJsonForm } from 'next-tinacms-json'
 
-import Layout from "../components/Layout";
-import BlogList from "../components/BlogList";
+import Layout from '../components/Layout'
+import BlogList from '../components/BlogList'
 
-const Index = (props) => {
-  // TINA CMS Config ---------------------------
-  const cms = useCMS()
-  const [data, form] = useLocalForm({
-    id: props.fileRelativePath, // needs to be unique
-    label: 'Site Config',
+const Index = ({ jsonFile, allBlogs }) => {
+	const formOptions = {
+		fields: [
+			{
+				name: 'title',
+				label: 'Site Title',
+				component: 'text'
+			},
+			{
+				name: 'description',
+				label: 'Site Description',
+				component: 'text'
+			},
+			{
+				name: 'repositoryUrl',
+				label: 'Repository Url',
+				component: 'text'
+			}
+		]
+	}
+	const [data] = useLocalJsonForm(jsonFile, formOptions)
 
-    // starting values for the post object
-    initialValues: {
-      fileRelativePath: props.fileRelativePath,
-      title: props.title,
-      description: props.description,
-      repositoryUrl: props.repositoryUrl
-    },
+	return (
+		<Layout
+			pathname='/'
+			siteTitle={data.title}
+			siteDescription={data.description}
+		>
+			<section>
+				<BlogList allBlogs={allBlogs} />
+			</section>
+		</Layout>
+	)
+}
 
-    // field definition
-    fields: [
-      {
-        name: 'title',
-        label: 'Site Title',
-        component: 'text'
-      },
-      {
-        name: 'description',
-        label: 'Site Description',
-        component: 'text'
-      },
-      {
-        name: 'repositoryUrl',
-        label: 'Repository Url',
-        component: 'text'
-      },
-    ],
-
-    // save & commit the file when the "save" button is pressed
-    onSubmit(data) {
-      return cms.api.git
-        .writeToDisk({
-          fileRelativePath: props.fileRelativePath,
-          content: JSON.stringify(formState.values),
-        })
-        .then(() => {
-          return cms.api.git.commit({
-            files: [props.fileRelativePath],
-            message: `Commit from Tina: Update ${data.fileRelativePath}`,
-          })
-        })
-    },
-  })
-
-  const writeToDisk = React.useCallback(formState => {
-
-    cms.api.git.onChange({
-      fileRelativePath: props.fileRelativePath,
-      content: JSON.stringify(formState.values),
-    })
-  }, [])
-
-  useWatchFormValues(form, writeToDisk)
-
-// END Tina CMS config -----------------------------
-  return (
-    <Layout pathname="/" siteTitle={data.title} siteDescription={data.description}>
-      <section>
-        <BlogList allBlogs={props.allBlogs} />
-      </section>
-      </Layout>
-  );
-};
-
-export default Index;
+export default Index
 
 Index.getInitialProps = async function() {
-  const content = await import(`../data/config.json`)
-     // get all blog data for list
-     const posts = (context => {
-      const keys = context.keys();
-      const values = keys.map(context);
-      const data = keys.map((key, index) => {
-        // Create slug from filename
-        const slug = key
-          .replace(/^.*[\\\/]/, "")
-          .split(".")
-          .slice(0, -1)
-          .join(".");
-        const value = values[index];
-        // Parse yaml metadata & markdownbody in document
-        const document = matter(value.default);
-        return {
-          document,
-          slug
-        };
-      });
-      return data;
-    })(require.context("../posts", true, /\.md$/));
+	const content = await import(`../data/config.json`)
+	// get all blog data for list
+	const posts = (context => {
+		const keys = context.keys()
+		const values = keys.map(context)
+		const data = keys.map((key, index) => {
+			// Create slug from filename
+			const slug = key
+				.replace(/^.*[\\\/]/, '')
+				.split('.')
+				.slice(0, -1)
+				.join('.')
+			const value = values[index]
+			// Parse yaml metadata & markdownbody in document
+			const document = matter(value.default)
+			return {
+				document,
+				slug
+			}
+		})
+		return data
+	})(require.context('../posts', true, /\.md$/))
 
-  return {
-    fileRelativePath: `src/data/config.json`,
-    allBlogs: posts,
-    ...content
-  }
+	return {
+		jsonFile: {
+			fileRelativePath: `src/data/config.json`,
+			data: content.default
+		},
+
+		allBlogs: posts
+	}
 }

--- a/src/pages/info.js
+++ b/src/pages/info.js
@@ -1,104 +1,68 @@
-import { useCMS, useLocalForm, useWatchFormValues } from 'tinacms'
-import matter from "gray-matter";
-import ReactMarkdown from "react-markdown";
+import matter from 'gray-matter'
+import ReactMarkdown from 'react-markdown'
+import { useLocalMarkdownForm } from 'next-tinacms-markdown'
 
-import Layout from "../components/Layout";
-import toMarkdownString from '../utils/toMarkdownString'
-
+import Layout from '../components/Layout'
 
 export default function Info(props) {
+	const formOptions = {
+		fields: [
+			{
+				name: 'frontmatter.background_color',
+				label: 'Background Color',
+				component: 'color'
+			},
+			{
+				name: 'markdownBody',
+				label: 'Info Content',
+				component: 'markdown'
+			}
+		]
+	}
+	const [data] = useLocalMarkdownForm(props.markdownFile, formOptions)
 
-  // TINA CMS Config ---------------------------
-  const cms = useCMS()
-  const [data, form] = useLocalForm({
-    id: props.fileRelativePath, // needs to be unique
-    label: 'Info Page',
+	return (
+		<Layout
+			pathname='info'
+			bgColor={data.frontmatter.background_color}
+			siteTitle={props.title}
+		>
+			<section className='info_blurb'>
+				<ReactMarkdown source={data.markdownBody} />
+			</section>
+			<style jsx>{`
+				.info_blurb {
+					max-width: 800px;
+					padding: 1.5rem 1.25rem;
+				}
 
-    // starting values for the post object
-    initialValues: {
-      fileRelativePath: props.fileRelativePath,
-      frontmatter: props.data,
-      markdownBody: props.content,
-    },
+				@media (min-width: 768px) {
+					.info_blurb {
+						padding: 2rem;
+					}
+				}
 
-    // field definition
-    fields: [
-      {
-        name: 'frontmatter.background_color',
-        label: 'Background Color',
-        component: 'color'
-      },
-      {
-        name: 'markdownBody',
-        label: 'Info Content',
-        component: 'markdown',
-      },
-      
-    ],
-
-    // save & commit the file when the "save" button is pressed
-    onSubmit(data) {
-      return cms.api.git
-        .writeToDisk({
-          fileRelativePath: props.fileRelativePath,
-          content: toMarkdownString(formState.values),
-        })
-        .then(() => {
-          return cms.api.git.commit({
-            files: [props.fileRelativePath],
-            message: `Commit from Tina: Update ${data.fileRelativePath}`,
-          })
-        })
-    },
-  })
-
-  const writeToDisk = React.useCallback(formState => {
-    cms.api.git.writeToDisk({
-      fileRelativePath: props.fileRelativePath,
-      content: toMarkdownString(formState.values),
-    })
-  }, [])
-
-  useWatchFormValues(form, writeToDisk)
-
-// END Tina CMS config -----------------------------
-
-  return (
-    <Layout pathname='info' bgColor={data.frontmatter.background_color} siteTitle={props.title}>
-      <section className="info_blurb">
-        <ReactMarkdown source={data.markdownBody} />
-      </section>
-      <style jsx>{`
-        .info_blurb {
-          max-width: 800px;
-          padding: 1.5rem 1.25rem;
-        }
-        
-        @media (min-width: 768px) {
-          .info_blurb {
-            padding: 2rem;
-          }
-        }
-        
-        @media (min-width: 1440px) {
-          .info_blurb {
-            padding: 3rem;
-          }
-        }
-      `}</style>
-    </Layout>
-  );
+				@media (min-width: 1440px) {
+					.info_blurb {
+						padding: 3rem;
+					}
+				}
+			`}</style>
+		</Layout>
+	)
 }
 
-
 Info.getInitialProps = async function() {
-  const content = await import(`../data/info.md`)
-  const config = await import(`../data/config.json`)
-  const data = matter(content.default)
+	const content = await import(`../data/info.md`)
+	const config = await import(`../data/config.json`)
+	const data = matter(content.default)
 
-  return {
-    fileRelativePath: `src/data/info.md`,
-    title: config.title,
-    ...data
-  }
+	return {
+		markdownFile: {
+			fileRelativePath: `src/data/info.md`,
+			frontmatter: data.data,
+			markdownBody: data.markdownFile
+		},
+		title: config.default.title
+	}
 }

--- a/src/pages/info.js
+++ b/src/pages/info.js
@@ -61,7 +61,7 @@ Info.getInitialProps = async function() {
 		markdownFile: {
 			fileRelativePath: `src/data/info.md`,
 			frontmatter: data.data,
-			markdownBody: data.markdownFile
+			markdownBody: data.content
 		},
 		title: config.default.title
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -945,26 +945,24 @@
     multer "1.4.2"
     simple-git "1.126.0"
 
-"@tinacms/core@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@tinacms/core/-/core-0.5.0.tgz#6d13b697b99679598447104fc3707f5b86717a0c"
-  integrity sha512-4pp+OfbqaOlWL/EZDozmZpQQPM6kcAdDp0Z9dXKD93r604jBWr6vSv3ZrBpjUHqgbaKeWxhS4n3pA09Wc3iOiA==
-  dependencies:
-    final-form "^4.18.2"
-    final-form-arrays "^3.0.1"
+"@tinacms/core@^0.7.1", "@tinacms/core@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@tinacms/core/-/core-0.7.2.tgz#c3d6f263beaf5e8358fbe3021509bac7f121f1c2"
+  integrity sha512-eM5GBN4MT6tY//JFrYjyy0Jm6/fe8KZwMZdSCJBQ5Ltw7wyXptNpmRuf3QRbEuZDz8KUzq8tYq2cNqKgKooFLg==
 
-"@tinacms/fields@^0.1.16":
-  version "0.1.16"
-  resolved "https://registry.yarnpkg.com/@tinacms/fields/-/fields-0.1.16.tgz#586079f226e344b1d51f8b0b18d273fb53752e00"
-  integrity sha512-T+puqZA1V16sI23WEYVMaBhYsHsEswv/OcX7VOffYl16MB9O5NTYrZkjtw8JwYlpcxYX703uIwd4DDdpTG7fQA==
+"@tinacms/fields@^0.5.0":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@tinacms/fields/-/fields-0.5.1.tgz#b30b75ebf5c7858733168362b2b2bd1c24e9a0dd"
+  integrity sha512-Ee7foA5mpSxncriy5K29llSliCx4pivhGmNSylRlKJDXGFlxIeGO6DeFxJopcYKqJZXRid2VV765WpWkKqs+wg==
   dependencies:
     "@sambego/storybook-styles" "^1.0.0"
-    "@tinacms/core" "^0.5.0"
-    "@tinacms/icons" "^0.3.9"
-    "@tinacms/styles" "^0.1.0"
+    "@tinacms/core" "^0.7.1"
+    "@tinacms/icons" "^0.5.2"
+    "@tinacms/styles" "^0.1.2"
     "@types/react-select" "^2.0.11"
     codemirror "^5.42.2"
     color-string "^1.5.3"
+    lodash.debounce "^4.0.8"
     lodash.get "^4.4.2"
     markdown-it "^8.3.1"
     prosemirror-commands "^1.0.8"
@@ -973,48 +971,57 @@
     prosemirror-history "^1.0.4"
     prosemirror-inputrules "^1.0.4"
     prosemirror-keymap "^1.0.1"
+    prosemirror-model "^1.0.0"
     prosemirror-schema-list "^1.0.3"
     prosemirror-state "^1.2.4"
-    prosemirror-tables "0.4.1"
+    prosemirror-tables "1.0.0"
+    prosemirror-transform "^1.0.0"
+    prosemirror-utils "^0.9.6"
     prosemirror-view "^1.11.3"
     react-color "^2.17.3"
-    react-dismissible "^1.0.17"
+    react-dismissible "^1.1.4"
     react-dropzone "10.1.8"
     react-select "^2.3.0"
 
-"@tinacms/form-builder@^0.2.8":
-  version "0.2.8"
-  resolved "https://registry.yarnpkg.com/@tinacms/form-builder/-/form-builder-0.2.8.tgz#6131e332ca4322fed2b712d1e6999a4fb32f9a38"
-  integrity sha512-DjFvKw81oGx94WRK/Q5SzFE/bbLcSKnOYN1gP+WsH8wnQLG1fYENCjq5fBKs3WoyV41mLgciaaPb48ITv5CJAA==
+"@tinacms/form-builder@^0.2.15":
+  version "0.2.16"
+  resolved "https://registry.yarnpkg.com/@tinacms/form-builder/-/form-builder-0.2.16.tgz#1397ea2cf0426f4c4497d3fdda30f861a7abc937"
+  integrity sha512-P6FOv9Tn0hfSfgRjQO2sNEBzI7eXHSwmZ1kVNPWruWZ3ArL+wXZzpMR/byrl5sAgnLJR8OEqFnkWr201rucAsQ==
   dependencies:
-    "@tinacms/core" "^0.5.0"
-    "@tinacms/react-core" "^0.2.0"
-    final-form "^4.18.2"
+    "@tinacms/forms" "^0.2.1"
+    "@tinacms/react-core" "^0.2.8"
     react-final-form "^6.3.0"
+
+"@tinacms/forms@^0.2.0", "@tinacms/forms@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@tinacms/forms/-/forms-0.2.1.tgz#ac0173310bbd1d1a924636517bd2ad356f2a01d7"
+  integrity sha512-5haR/sMsRRM4NN5s9tq8WY+A1y6LEQG0N9Ny0+UYK6LsYmwIBkz5KNsEaPYdKXWGPw6y7JuvzabJ6jgocfyYHQ==
+  dependencies:
+    final-form "^4.18.2"
+    final-form-arrays "^3.0.1"
 
 "@tinacms/git-client@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@tinacms/git-client/-/git-client-0.4.1.tgz#f6b870944ba7aec9a7829061a297804e95478f70"
   integrity sha512-DIQj7oaB0xFjBfo52obVljbFP7+Vjgr6CICXiBBbL53f18sVzWy2OITLyQEaSv0uuNva/Z53dm+Uy+fNpkyopA==
 
-"@tinacms/icons@^0.3.9":
-  version "0.3.9"
-  resolved "https://registry.yarnpkg.com/@tinacms/icons/-/icons-0.3.9.tgz#ff6512d2cc1b01d294aa7d4c54061b2213b69f8d"
-  integrity sha512-iyWxPhWuW9MmOPPef0LN6Xq0d9M6hcnoqtbOtHqBTRmA0f696oNlIMS9cKZzBklpJNtEUGNYWGhg6KmGkLtq+A==
+"@tinacms/icons@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@tinacms/icons/-/icons-0.5.2.tgz#6ea07aabb769dea137f12bfffc53829c21dc04af"
+  integrity sha512-VEBAsMu5hmMkaWkq5mpahl4Jsh4tKM5WhgNBClTCDZGcWvqJF6NlJJEpCbGPDOWaqpsRj+66a/9CKNCuNutv+w==
 
-"@tinacms/react-core@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@tinacms/react-core/-/react-core-0.2.0.tgz#a4c6ecb2b24d0947c94f59b4a96dd50adda5f007"
-  integrity sha512-N+nm+irhtfO/Ic26W52Kl3jI6JxIcBPyZcvCBvp86or8tdVi4oCnI4HickVLXmrwfRs0FupK2CHmaWjFEV9m+g==
+"@tinacms/react-core@^0.2.7", "@tinacms/react-core@^0.2.8":
+  version "0.2.8"
+  resolved "https://registry.yarnpkg.com/@tinacms/react-core/-/react-core-0.2.8.tgz#985e87abf804415bcb6c569a639722ef35070d6d"
+  integrity sha512-Hw90KUHmxt3iPDVRgjP6Fq13DnYc3s6OpPshn7PVdQCxWmjqCr8dZqppHhJofuogeQurXxBo+RLhphvSlx+0KQ==
   dependencies:
-    "@tinacms/core" "^0.5.0"
-    lodash.get "^4.4.2"
-    lodash.set "^4.3.2"
+    "@tinacms/core" "^0.7.2"
+    "@tinacms/forms" "^0.2.1"
 
-"@tinacms/styles@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@tinacms/styles/-/styles-0.1.0.tgz#f928d678001a3f44987dfec28d00f7e3c6e67003"
-  integrity sha512-w2QWKKfQaovxdRqH0IxytoA6orlU66FnoTjqwYxPYV06llKZBISUOquOK8GyywMN6kpKlMdAKxennk5DFII5Ww==
+"@tinacms/styles@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@tinacms/styles/-/styles-0.1.2.tgz#6bed4d78d52268901f105f0252302d69472c12a3"
+  integrity sha512-cPvJZmvvloOuc/HLHrTjh7EWmnBjqAYmraQAQdzOlpp4+lED3vAQlZm0tvpNEsswNCdnidLzXfGuR0P3/KhdUw==
 
 "@types/body-parser@*":
   version "1.17.1"
@@ -3849,6 +3856,16 @@ lodash.camelcase@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
@@ -3858,11 +3875,6 @@ lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
-
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
 
 lodash.template@^4.5.0:
   version "4.5.0"
@@ -4262,6 +4274,11 @@ neo-async@^2.5.0, neo-async@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
+
+next-tinacms-json@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/next-tinacms-json/-/next-tinacms-json-0.3.5.tgz#206544349558da9d8a406ea2808af98e44d6ca4f"
+  integrity sha512-SAr/LMN5UU5Z+KScpfeQXzyfRIsMfSaGTscx6VUMkWBDJpuCmFJn4nTNye9POtXYtPkDE9EF+FH8/vJ0N/Ndqg==
 
 next@^9.0.6:
   version "9.1.4"
@@ -5358,7 +5375,7 @@ prosemirror-inputrules@^1.0.4:
     prosemirror-state "^1.0.0"
     prosemirror-transform "^1.0.0"
 
-prosemirror-keymap@^1.0.0, prosemirror-keymap@^1.0.1:
+prosemirror-keymap@^1.0.0, prosemirror-keymap@^1.0.1, prosemirror-keymap@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/prosemirror-keymap/-/prosemirror-keymap-1.1.3.tgz#be22d6108df2521608e9216a87b1a810f0ed361e"
   integrity sha512-PRA4NzkUMzV/NFf5pyQ6tmlIHiW/qjQ1kGWUlV2rF/dvlOxtpGpTEjIMhWgLuMf+HiDEFnUEP7uhYXu+t+491g==
@@ -5373,6 +5390,13 @@ prosemirror-model@^1.0.0, prosemirror-model@^1.1.0:
   dependencies:
     orderedmap "^1.1.0"
 
+prosemirror-model@^1.8.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/prosemirror-model/-/prosemirror-model-1.9.1.tgz#8c08cf556f593c5f015548d2c1a6825661df087f"
+  integrity sha512-Qblh8pm1c7Ll64sYLauwwzjimo/tFg1zW3Q3IWhKRhvfOEgRKqa6dC5pRrAa+XHOIjBFEYrqbi52J5bqA2dV8Q==
+  dependencies:
+    orderedmap "^1.1.0"
+
 prosemirror-schema-list@^1.0.3:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prosemirror-schema-list/-/prosemirror-schema-list-1.1.2.tgz#310809209094b03425da7f5c337105074913da6c"
@@ -5381,7 +5405,7 @@ prosemirror-schema-list@^1.0.3:
     prosemirror-model "^1.0.0"
     prosemirror-transform "^1.0.0"
 
-prosemirror-state@^1.0.0, prosemirror-state@^1.2.2, prosemirror-state@^1.2.4:
+prosemirror-state@^1.0.0, prosemirror-state@^1.2.2, prosemirror-state@^1.2.4, prosemirror-state@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/prosemirror-state/-/prosemirror-state-1.3.2.tgz#1b910b0dc01c1f00926bb9ba1589f7b7ac0d658b"
   integrity sha512-t/JqE3aR0SV9QrzFVkAXsQwsgrQBNs/BDbcFH20RssW0xauqNNdjTXxy/J/kM7F+0zYi6+BRmz7cMMQQFU3mwQ==
@@ -5389,16 +5413,16 @@ prosemirror-state@^1.0.0, prosemirror-state@^1.2.2, prosemirror-state@^1.2.4:
     prosemirror-model "^1.0.0"
     prosemirror-transform "^1.0.0"
 
-prosemirror-tables@0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/prosemirror-tables/-/prosemirror-tables-0.4.1.tgz#7aa5fb1db2915008c8a5142adf5bd3f1679ce0a8"
-  integrity sha1-eqX7HbKRUAjIpRQq31vT8Wec4Kg=
+prosemirror-tables@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prosemirror-tables/-/prosemirror-tables-1.0.0.tgz#ec3d0b11e638c6a92dd14ae816d0a2efd1719b70"
+  integrity sha512-zFw5Us4G5Vdq0yIj8GiqZOGA6ud5UKpMKElux9O0HrfmhkuGa1jf1PCpz2R5pmIQJv+tIM24H1mox/ODBAX37Q==
   dependencies:
-    prosemirror-keymap "^1.0.0"
-    prosemirror-model "^1.0.0"
-    prosemirror-state "^1.0.0"
-    prosemirror-transform "^1.0.0"
-    prosemirror-view "^1.0.0"
+    prosemirror-keymap "^1.1.2"
+    prosemirror-model "^1.8.1"
+    prosemirror-state "^1.3.1"
+    prosemirror-transform "^1.2.1"
+    prosemirror-view "^1.13.3"
 
 prosemirror-transform@^1.0.0, prosemirror-transform@^1.1.0:
   version "1.2.2"
@@ -5407,10 +5431,31 @@ prosemirror-transform@^1.0.0, prosemirror-transform@^1.1.0:
   dependencies:
     prosemirror-model "^1.0.0"
 
+prosemirror-transform@^1.2.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/prosemirror-transform/-/prosemirror-transform-1.2.4.tgz#8d5843834f5ccedfb614faa9220672bb4834b00a"
+  integrity sha512-0A668uf0EN89L9O9brE05kHcqp7FHmT5YN7Tom58Kj926QqOBs7iNRHDLWxrSaQB5MNZtzDOD9T3EyJ88YDcBg==
+  dependencies:
+    prosemirror-model "^1.0.0"
+
+prosemirror-utils@^0.9.6:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/prosemirror-utils/-/prosemirror-utils-0.9.6.tgz#3d97bd85897e3b535555867dc95a51399116a973"
+  integrity sha512-UC+j9hQQ1POYfMc5p7UFxBTptRiGPR7Kkmbl3jVvU8VgQbkI89tR/GK+3QYC8n+VvBZrtAoCrJItNhWSxX3slA==
+
 prosemirror-view@^1.0.0, prosemirror-view@^1.1.0, prosemirror-view@^1.11.3:
   version "1.13.4"
   resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.13.4.tgz#01d873db7731e0aacc410a9038447d1b7536fd07"
   integrity sha512-mtgWEK16uYQFk3kijRlkSpAmDuy7rxYuv0pgyEBDmLT1PCPY8380CoaYnP8znUT6BXIGlJ8oTveK3M50U+B0vw==
+  dependencies:
+    prosemirror-model "^1.1.0"
+    prosemirror-state "^1.0.0"
+    prosemirror-transform "^1.1.0"
+
+prosemirror-view@^1.13.3:
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.14.2.tgz#23eb89f6101e9671b5e0c19d82ee0ad9de5608de"
+  integrity sha512-9yPVH6OLyaEraHjWHbSk2DB0R/1TsEE6AA1LI+vmCypXXA+zTzNrktUFzBhSJHehXDoEJcQfnl1Wdp5GPSh2+g==
   dependencies:
     prosemirror-model "^1.1.0"
     prosemirror-state "^1.0.0"
@@ -5605,10 +5650,10 @@ react-datetime@^2.16.3:
     prop-types "^15.5.7"
     react-onclickoutside "^6.5.0"
 
-react-dismissible@^1.0.17:
-  version "1.0.17"
-  resolved "https://registry.yarnpkg.com/react-dismissible/-/react-dismissible-1.0.17.tgz#4893229ba014c61d066f34861bd48db3ed46c3d9"
-  integrity sha512-vdfi+136SAOJlHTKtBM9c7JxSwJD03dR1zZBqIQ97m+6wljEG1inh+n6r6Z40l6yrzotFq1EFDk4hn2dtKUy/w==
+react-dismissible@^1.1.4:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/react-dismissible/-/react-dismissible-1.1.5.tgz#363afd0b004292ad0ffb84d28406dbc86e114652"
+  integrity sha512-gUSNT2gz65Uq8gQadDzCrOP0WoXD7ldnMGrL5ZISTdB2Jhw+TL1Xd04p5CYmhBwIFUO5p+hEAEWlZRz0Wve/FQ==
 
 react-dom@^16.8.6:
   version "16.12.0"
@@ -5641,11 +5686,6 @@ react-final-form@^6.3.0:
   dependencies:
     "@babel/runtime" "^7.4.5"
     ts-essentials "^3.0.2"
-
-react-frame-component@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-4.1.1.tgz#ea8f7c518ef6b5ad72146dd1f648752369826894"
-  integrity sha512-NfJp90AvYA1R6+uSYafQ+n+UM2HjHqi4WGHeprVXa6quU9d8o6ZFRzQ36uemY82dlkZFzf2jigFx6E4UzNFajA==
 
 react-input-autosize@^2.2.1:
   version "2.2.2"
@@ -6534,23 +6574,24 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
-tinacms@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/tinacms/-/tinacms-0.10.0.tgz#41cd73ac25c6f6f82ddc2d951546774bdc3af35e"
-  integrity sha512-f4f0RMEM/v3UpmNkkofuRLWtTVfo6Mui5CMkXMEcEsspTdHFqJa1Qgt+NF/HOM7rcloYSU4FTw+cfwevmhIRQQ==
+tinacms@^0.13.0:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/tinacms/-/tinacms-0.13.1.tgz#94cc9dec10249f226134803b63d0b6430bcddfc6"
+  integrity sha512-GefrYlCa3Cogv6YomrM4JW/fCBMD/VxjeCrArS/hRPcZxe1gOjKGDeW3Bb1QYOsXVVdsv4eFcH+k1JFYnrKPjw==
   dependencies:
-    "@tinacms/core" "^0.5.0"
-    "@tinacms/fields" "^0.1.16"
-    "@tinacms/form-builder" "^0.2.8"
-    "@tinacms/icons" "^0.3.9"
-    "@tinacms/react-core" "^0.2.0"
-    "@tinacms/styles" "^0.1.0"
+    "@tinacms/core" "^0.7.1"
+    "@tinacms/fields" "^0.5.0"
+    "@tinacms/form-builder" "^0.2.15"
+    "@tinacms/forms" "^0.2.0"
+    "@tinacms/icons" "^0.5.2"
+    "@tinacms/react-core" "^0.2.7"
+    "@tinacms/styles" "^0.1.2"
     "@types/react-beautiful-dnd" "^11.0.3"
+    lodash.clonedeep "^4.5.0"
     lodash.merge "^4.6.2"
     react-beautiful-dnd "^11.0.5"
     react-datetime "^2.16.3"
-    react-dismissible "^1.0.17"
-    react-frame-component "^4.1.1"
+    react-dismissible "^1.1.4"
 
 tiny-invariant@^1.0.4, tiny-invariant@^1.0.6:
   version "1.0.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4280,6 +4280,14 @@ next-tinacms-json@^0.3.5:
   resolved "https://registry.yarnpkg.com/next-tinacms-json/-/next-tinacms-json-0.3.5.tgz#206544349558da9d8a406ea2808af98e44d6ca4f"
   integrity sha512-SAr/LMN5UU5Z+KScpfeQXzyfRIsMfSaGTscx6VUMkWBDJpuCmFJn4nTNye9POtXYtPkDE9EF+FH8/vJ0N/Ndqg==
 
+next-tinacms-markdown@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/next-tinacms-markdown/-/next-tinacms-markdown-0.2.5.tgz#becfbf63bf0279186148afb2e91cef4a9b6ce6c1"
+  integrity sha512-jWXsaFlTzFqlB7LBIEIj5EA6WtfffltO8yZSNWYV+FBCfuu5QOnhgfazbL0XCRkrFWi5iPTVT4KqIhO8wQ1cHg==
+  dependencies:
+    gray-matter "^4.0.2"
+    js-yaml "^3.13.1"
+
 next@^9.0.6:
   version "9.1.4"
   resolved "https://registry.yarnpkg.com/next/-/next-9.1.4.tgz#32991dd6b49adca4bac302828eb5a1b3654591b6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -800,7 +800,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2":
+"@babel/runtime@^7.3.1", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5":
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.7.2.tgz#111a78002a5c25fc8e3361bedc9529c696b85a6a"
   integrity sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==
@@ -860,23 +860,6 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@emotion/babel-utils@^0.6.4":
-  version "0.6.10"
-  resolved "https://registry.yarnpkg.com/@emotion/babel-utils/-/babel-utils-0.6.10.tgz#83dbf3dfa933fae9fc566e54fbb45f14674c6ccc"
-  integrity sha512-/fnkM/LTEp3jKe++T0KyTszVGWNKPNOUJfjNKLO17BzQ6QPxgbg3whayom1Qr2oLFH3V92tDymU+dT5q676uow==
-  dependencies:
-    "@emotion/hash" "^0.6.6"
-    "@emotion/memoize" "^0.6.6"
-    "@emotion/serialize" "^0.9.1"
-    convert-source-map "^1.5.1"
-    find-root "^1.1.0"
-    source-map "^0.7.2"
-
-"@emotion/hash@^0.6.2", "@emotion/hash@^0.6.6":
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.6.6.tgz#62266c5f0eac6941fece302abad69f2ee7e25e44"
-  integrity sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ==
-
 "@emotion/is-prop-valid@^0.8.1":
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.5.tgz#2dda0791f0eafa12b7a0a5b39858405cc7bde983"
@@ -889,40 +872,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.3.tgz#5b6b1c11d6a6dddf1f2fc996f74cf3b219644d78"
   integrity sha512-2Md9mH6mvo+ygq1trTeVp2uzAKwE2P7In0cRpD/M9Q70aH8L+rxMLbb3JCN2JoSWsV2O+DdFjfbbXoMoLBczow==
 
-"@emotion/memoize@^0.6.1", "@emotion/memoize@^0.6.6":
-  version "0.6.6"
-  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.6.6.tgz#004b98298d04c7ca3b4f50ca2035d4f60d2eed1b"
-  integrity sha512-h4t4jFjtm1YV7UirAFuSuFGyLa+NNxjdkq6DpFLANNQY5rHueFZHVY+8Cu1HYVP6DrheB0kv4m5xPjo7eKT7yQ==
-
-"@emotion/serialize@^0.9.1":
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.9.1.tgz#a494982a6920730dba6303eb018220a2b629c145"
-  integrity sha512-zTuAFtyPvCctHBEL8KZ5lJuwBanGSutFEncqLn/m9T1a6a93smBStK+bZzcNPgj4QS8Rkw9VTwJGhRIUVO8zsQ==
-  dependencies:
-    "@emotion/hash" "^0.6.6"
-    "@emotion/memoize" "^0.6.6"
-    "@emotion/unitless" "^0.6.7"
-    "@emotion/utils" "^0.8.2"
-
-"@emotion/stylis@^0.7.0":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.7.1.tgz#50f63225e712d99e2b2b39c19c70fff023793ca5"
-  integrity sha512-/SLmSIkN13M//53TtNxgxo57mcJk/UJIDFRKwOiLIBEyBHEcipgR6hNMQ/59Sl4VjCJ0Z/3zeAZyvnSLPG/1HQ==
-
-"@emotion/unitless@^0.6.2", "@emotion/unitless@^0.6.7":
-  version "0.6.7"
-  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.6.7.tgz#53e9f1892f725b194d5e6a1684a7b394df592397"
-  integrity sha512-Arj1hncvEVqQ2p7Ega08uHLr1JuRYBuO5cIvcA+WWEQ5+VmkOE3ZXzl04NbQxeQpWX78G7u6MqxKuNX3wvYZxg==
-
 "@emotion/unitless@^0.7.0":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.4.tgz#a87b4b04e5ae14a88d48ebef15015f6b7d1f5677"
   integrity sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ==
-
-"@emotion/utils@^0.8.2":
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.8.2.tgz#576ff7fb1230185b619a75d258cbc98f0867a8dc"
-  integrity sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw==
 
 "@icons/material@^0.2.4":
   version "0.2.4"
@@ -945,20 +898,20 @@
     multer "1.4.2"
     simple-git "1.126.0"
 
-"@tinacms/core@^0.7.1", "@tinacms/core@^0.7.2":
+"@tinacms/core@^0.7.2":
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/@tinacms/core/-/core-0.7.2.tgz#c3d6f263beaf5e8358fbe3021509bac7f121f1c2"
   integrity sha512-eM5GBN4MT6tY//JFrYjyy0Jm6/fe8KZwMZdSCJBQ5Ltw7wyXptNpmRuf3QRbEuZDz8KUzq8tYq2cNqKgKooFLg==
 
-"@tinacms/fields@^0.5.0":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@tinacms/fields/-/fields-0.5.1.tgz#b30b75ebf5c7858733168362b2b2bd1c24e9a0dd"
-  integrity sha512-Ee7foA5mpSxncriy5K29llSliCx4pivhGmNSylRlKJDXGFlxIeGO6DeFxJopcYKqJZXRid2VV765WpWkKqs+wg==
+"@tinacms/fields@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@tinacms/fields/-/fields-0.7.0.tgz#2eee21774c753eba0669e19e83a026840f4e5300"
+  integrity sha512-MsX0w8tBF9UBnWtlBAh/k+BRD6j5quG32zscY0BoPE9+OItcUap1il/tiRvL/jVNB/2hwMML80sko0lj2APIEg==
   dependencies:
     "@sambego/storybook-styles" "^1.0.0"
-    "@tinacms/core" "^0.7.1"
-    "@tinacms/icons" "^0.5.2"
-    "@tinacms/styles" "^0.1.2"
+    "@tinacms/core" "^0.7.2"
+    "@tinacms/icons" "^0.7.0"
+    "@tinacms/styles" "^0.3.0"
     "@types/react-select" "^2.0.11"
     codemirror "^5.42.2"
     color-string "^1.5.3"
@@ -979,11 +932,10 @@
     prosemirror-utils "^0.9.6"
     prosemirror-view "^1.11.3"
     react-color "^2.17.3"
-    react-dismissible "^1.1.4"
+    react-dismissible "^1.1.5"
     react-dropzone "10.1.8"
-    react-select "^2.3.0"
 
-"@tinacms/form-builder@^0.2.15":
+"@tinacms/form-builder@^0.2.16":
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/@tinacms/form-builder/-/form-builder-0.2.16.tgz#1397ea2cf0426f4c4497d3fdda30f861a7abc937"
   integrity sha512-P6FOv9Tn0hfSfgRjQO2sNEBzI7eXHSwmZ1kVNPWruWZ3ArL+wXZzpMR/byrl5sAgnLJR8OEqFnkWr201rucAsQ==
@@ -992,7 +944,7 @@
     "@tinacms/react-core" "^0.2.8"
     react-final-form "^6.3.0"
 
-"@tinacms/forms@^0.2.0", "@tinacms/forms@^0.2.1":
+"@tinacms/forms@^0.2.1":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@tinacms/forms/-/forms-0.2.1.tgz#ac0173310bbd1d1a924636517bd2ad356f2a01d7"
   integrity sha512-5haR/sMsRRM4NN5s9tq8WY+A1y6LEQG0N9Ny0+UYK6LsYmwIBkz5KNsEaPYdKXWGPw6y7JuvzabJ6jgocfyYHQ==
@@ -1005,12 +957,12 @@
   resolved "https://registry.yarnpkg.com/@tinacms/git-client/-/git-client-0.4.1.tgz#f6b870944ba7aec9a7829061a297804e95478f70"
   integrity sha512-DIQj7oaB0xFjBfo52obVljbFP7+Vjgr6CICXiBBbL53f18sVzWy2OITLyQEaSv0uuNva/Z53dm+Uy+fNpkyopA==
 
-"@tinacms/icons@^0.5.2":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@tinacms/icons/-/icons-0.5.2.tgz#6ea07aabb769dea137f12bfffc53829c21dc04af"
-  integrity sha512-VEBAsMu5hmMkaWkq5mpahl4Jsh4tKM5WhgNBClTCDZGcWvqJF6NlJJEpCbGPDOWaqpsRj+66a/9CKNCuNutv+w==
+"@tinacms/icons@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@tinacms/icons/-/icons-0.7.0.tgz#aaf7ff6233dd4c06b5396373e0b6d4d93fd9d47e"
+  integrity sha512-3XE2KX++Wc2Y1Pl8U61Rvlz9lohyRdH7o6Jy+zfkcxUav/i6tEUL7tdepCj2LWeTmWqo8S3E89KsHroZbTg4OQ==
 
-"@tinacms/react-core@^0.2.7", "@tinacms/react-core@^0.2.8":
+"@tinacms/react-core@^0.2.8":
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/@tinacms/react-core/-/react-core-0.2.8.tgz#985e87abf804415bcb6c569a639722ef35070d6d"
   integrity sha512-Hw90KUHmxt3iPDVRgjP6Fq13DnYc3s6OpPshn7PVdQCxWmjqCr8dZqppHhJofuogeQurXxBo+RLhphvSlx+0KQ==
@@ -1018,10 +970,10 @@
     "@tinacms/core" "^0.7.2"
     "@tinacms/forms" "^0.2.1"
 
-"@tinacms/styles@^0.1.2":
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/@tinacms/styles/-/styles-0.1.2.tgz#6bed4d78d52268901f105f0252302d69472c12a3"
-  integrity sha512-cPvJZmvvloOuc/HLHrTjh7EWmnBjqAYmraQAQdzOlpp4+lED3vAQlZm0tvpNEsswNCdnidLzXfGuR0P3/KhdUw==
+"@tinacms/styles@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@tinacms/styles/-/styles-0.3.0.tgz#a14bfa1c38e699ec0bc42c5cc333fa8b5178bc77"
+  integrity sha512-/dFND/uDPzBiS7NWYWEnpHqZz/w5GGT+pC8h5wpuEY3wNupma2Baek2vyhfA1XZ0955NIWrTk/3YLGADHIXrGA==
 
 "@types/body-parser@*":
   version "1.17.1"
@@ -1071,11 +1023,6 @@
   version "12.12.14"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.12.14.tgz#1c1d6e3c75dba466e0326948d56e8bd72a1903d2"
   integrity sha512-u/SJDyXwuihpwjXy7hOOghagLEV1KdAST6syfnOk6QZAMzZuWZqXy5aYYZbh8Jdpd4escVFP0MvftHNDb9pruA==
-
-"@types/parse-json@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
-  integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
 "@types/prop-types@*":
   version "15.7.3"
@@ -1559,33 +1506,6 @@ babel-plugin-dynamic-import-node@^2.3.0:
   dependencies:
     object.assign "^4.1.0"
 
-babel-plugin-emotion@^9.2.11:
-  version "9.2.11"
-  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-9.2.11.tgz#319c005a9ee1d15bb447f59fe504c35fd5807728"
-  integrity sha512-dgCImifnOPPSeXod2znAmgc64NhaaOjGEHROR/M+lmStb3841yK1sgaDYAYMnlvWNz8GnpwIPN0VmNpbWYZ+VQ==
-  dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    "@emotion/babel-utils" "^0.6.4"
-    "@emotion/hash" "^0.6.2"
-    "@emotion/memoize" "^0.6.1"
-    "@emotion/stylis" "^0.7.0"
-    babel-plugin-macros "^2.0.0"
-    babel-plugin-syntax-jsx "^6.18.0"
-    convert-source-map "^1.5.0"
-    find-root "^1.1.0"
-    mkdirp "^0.5.1"
-    source-map "^0.5.7"
-    touch "^2.0.1"
-
-babel-plugin-macros@^2.0.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.7.0.tgz#f409a674cbbe548b60cbdf495ec059a2de429ab7"
-  integrity sha512-eV/9IWjmwT/TDCrNzA9sgO/j+x1dWAdLds7KLTY/emkLimzYbiXugfa0EO9IMkLeBBYvS0OdY+6pkF5VGf0iog==
-  dependencies:
-    "@babel/runtime" "^7.7.2"
-    cosmiconfig "^6.0.0"
-    resolve "^1.12.0"
-
 "babel-plugin-styled-components@>= 1":
   version "1.10.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.6.tgz#f8782953751115faf09a9f92431436912c34006b"
@@ -1890,11 +1810,6 @@ callsites@^2.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
   integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
 
-callsites@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
-  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
-
 camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
@@ -1998,11 +1913,6 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
-
-classnames@^2.2.5:
-  version "2.2.6"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
-  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
 cli-cursor@^2.1.0:
   version "2.1.0"
@@ -2171,7 +2081,7 @@ content-type@1.0.4, content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
-convert-source-map@1.7.0, convert-source-map@^1.1.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
+convert-source-map@1.7.0, convert-source-map@^1.1.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
   integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
@@ -2246,17 +2156,6 @@ cosmiconfig@^5.0.0:
     js-yaml "^3.13.1"
     parse-json "^4.0.0"
 
-cosmiconfig@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-6.0.0.tgz#da4fee853c52f6b1e6935f41c1a2fc50bd4a9982"
-  integrity sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==
-  dependencies:
-    "@types/parse-json" "^4.0.0"
-    import-fresh "^3.1.0"
-    parse-json "^5.0.0"
-    path-type "^4.0.0"
-    yaml "^1.7.2"
-
 create-ecdh@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.3.tgz#c9111b6f33045c4697f144787f9254cdc77c45ff"
@@ -2264,19 +2163,6 @@ create-ecdh@^4.0.0:
   dependencies:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
-
-create-emotion@^9.2.12:
-  version "9.2.12"
-  resolved "https://registry.yarnpkg.com/create-emotion/-/create-emotion-9.2.12.tgz#0fc8e7f92c4f8bb924b0fef6781f66b1d07cb26f"
-  integrity sha512-P57uOF9NL2y98Xrbl2OuiDQUZ30GVmASsv5fbsjF4Hlraip2kyAvMm+2PoYUvFFw03Fhgtxk3RqZSm2/qHL9hA==
-  dependencies:
-    "@emotion/hash" "^0.6.2"
-    "@emotion/memoize" "^0.6.1"
-    "@emotion/stylis" "^0.7.0"
-    "@emotion/unitless" "^0.6.2"
-    csstype "^2.5.2"
-    stylis "^3.5.0"
-    stylis-rule-sheet "^0.0.10"
 
 create-hash@^1.1.0, create-hash@^1.1.2:
   version "1.2.0"
@@ -2428,7 +2314,7 @@ cssnano-simple@1.0.0:
     cssnano-preset-simple "^1.0.0"
     postcss "^7.0.18"
 
-csstype@^2.2.0, csstype@^2.5.2:
+csstype@^2.2.0:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.7.tgz#20b0024c20b6718f4eda3853a1f5a1cce7f5e4a5"
   integrity sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ==
@@ -2567,13 +2453,6 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
-dom-helpers@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
-  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-
 dom-serializer@^0.2.1:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.2.2.tgz#1afb81f533717175d478655debc5e332d9f9bb51"
@@ -2657,14 +2536,6 @@ emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
   integrity sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
-
-emotion@^9.1.2:
-  version "9.2.12"
-  resolved "https://registry.yarnpkg.com/emotion/-/emotion-9.2.12.tgz#53925aaa005614e65c6e43db8243c843574d1ea9"
-  integrity sha512-hcx7jppaI8VoXxIWEhxpDW7I+B4kq9RNzQLmsrF6LY8BGKqe2N+gFAQr0EfuFucFlPs2A9HM4+xNj4NeqEWIOQ==
-  dependencies:
-    babel-plugin-emotion "^9.2.11"
-    create-emotion "^9.2.12"
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -2959,11 +2830,6 @@ find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
     commondir "^1.0.1"
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
-
-find-root@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
-  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
 
 find-up@4.0.0:
   version "4.0.0"
@@ -3357,14 +3223,6 @@ import-fresh@^2.0.0:
   dependencies:
     caller-path "^2.0.0"
     resolve-from "^3.0.0"
-
-import-fresh@^3.1.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
-  integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
-  dependencies:
-    parent-module "^1.0.0"
-    resolve-from "^4.0.0"
 
 import-from@^2.1.0:
   version "2.1.0"
@@ -3786,11 +3644,6 @@ launch-editor@2.2.1:
   dependencies:
     chalk "^2.3.0"
     shell-quote "^1.6.1"
-
-lines-and-columns@^1.1.6:
-  version "1.1.6"
-  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
-  integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
 linkify-it@^2.0.0:
   version "2.2.0"
@@ -4439,13 +4292,6 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
-nopt@~1.0.10:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
-  integrity sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=
-  dependencies:
-    abbrev "1"
-
 normalize-package-data@^2.3.2:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -4694,13 +4540,6 @@ parallel-transform@^1.1.0:
     inherits "^2.0.3"
     readable-stream "^2.1.5"
 
-parent-module@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
-  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
-  dependencies:
-    callsites "^3.0.0"
-
 parse-asn1@^5.0.0:
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/parse-asn1/-/parse-asn1-5.1.5.tgz#003271343da58dc94cace494faef3d2147ecea0e"
@@ -4739,16 +4578,6 @@ parse-json@^4.0.0:
   dependencies:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
-
-parse-json@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.0.0.tgz#73e5114c986d143efa3712d4ea24db9a4266f60f"
-  integrity sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    error-ex "^1.3.1"
-    json-parse-better-errors "^1.0.1"
-    lines-and-columns "^1.1.6"
 
 parse5-htmlparser2-tree-adapter@5.1.0:
   version "5.1.0"
@@ -4824,11 +4653,6 @@ path-type@^2.0.0:
   dependencies:
     pify "^2.0.0"
 
-path-type@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
-  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
-
 pbkdf2@^3.0.3:
   version "3.0.17"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
@@ -4839,11 +4663,6 @@ pbkdf2@^3.0.3:
     ripemd160 "^2.0.1"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
-
-performance-now@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
-  integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
 pify@^2.0.0:
   version "2.3.0"
@@ -5329,7 +5148,7 @@ prop-types-exact@1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@15.7.2, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -5562,13 +5381,6 @@ raf-schd@^4.0.0:
   resolved "https://registry.yarnpkg.com/raf-schd/-/raf-schd-4.0.2.tgz#bd44c708188f2e84c810bf55fcea9231bcaed8a0"
   integrity sha512-VhlMZmGy6A6hrkJWHLNTGl5gtgMUm+xfGza6wbwnE914yeQ5Ybm18vgM734RZhMgfw4tacUrWseGZlpUrrakEQ==
 
-raf@^3.4.0:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
-  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
-  dependencies:
-    performance-now "^2.1.0"
-
 ramda@^0.26:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
@@ -5658,7 +5470,7 @@ react-datetime@^2.16.3:
     prop-types "^15.5.7"
     react-onclickoutside "^6.5.0"
 
-react-dismissible@^1.1.4:
+react-dismissible@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/react-dismissible/-/react-dismissible-1.1.5.tgz#363afd0b004292ad0ffb84d28406dbc86e114652"
   integrity sha512-gUSNT2gz65Uq8gQadDzCrOP0WoXD7ldnMGrL5ZISTdB2Jhw+TL1Xd04p5CYmhBwIFUO5p+hEAEWlZRz0Wve/FQ==
@@ -5695,13 +5507,6 @@ react-final-form@^6.3.0:
     "@babel/runtime" "^7.4.5"
     ts-essentials "^3.0.2"
 
-react-input-autosize@^2.2.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.2.tgz#fcaa7020568ec206bc04be36f4eb68e647c4d8c2"
-  integrity sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==
-  dependencies:
-    prop-types "^15.5.8"
-
 react-is@16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
@@ -5711,11 +5516,6 @@ react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6, react-is
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
-
-react-lifecycles-compat@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
-  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
 react-markdown@^4.1.0:
   version "4.2.2"
@@ -5747,29 +5547,6 @@ react-redux@^7.0.3:
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
     react-is "^16.9.0"
-
-react-select@^2.3.0:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-2.4.4.tgz#ba72468ef1060c7d46fbb862b0748f96491f1f73"
-  integrity sha512-C4QPLgy9h42J/KkdrpVxNmkY6p4lb49fsrbDk/hRcZpX7JvZPNb6mGj+c5SzyEtBv1DmQ9oPH4NmhAFvCrg8Jw==
-  dependencies:
-    classnames "^2.2.5"
-    emotion "^9.1.2"
-    memoize-one "^5.0.0"
-    prop-types "^15.6.0"
-    raf "^3.4.0"
-    react-input-autosize "^2.2.1"
-    react-transition-group "^2.2.1"
-
-react-transition-group@^2.2.1:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
-  integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==
-  dependencies:
-    dom-helpers "^3.4.0"
-    loose-envify "^1.4.0"
-    prop-types "^15.6.2"
-    react-lifecycles-compat "^3.0.4"
 
 react@^16.8.6:
   version "16.12.0"
@@ -5948,11 +5725,6 @@ resolve-from@^3.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
   integrity sha1-six699nWiBvItuZTM17rywoYh0g=
 
-resolve-from@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
-  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
-
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
@@ -5962,13 +5734,6 @@ resolve@^1.10.0, resolve@^1.3.2, resolve@^1.8.1:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.13.1.tgz#be0aa4c06acd53083505abb35f4d66932ab35d16"
   integrity sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==
-  dependencies:
-    path-parse "^1.0.6"
-
-resolve@^1.12.0:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
-  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
   dependencies:
     path-parse "^1.0.6"
 
@@ -6249,12 +6014,12 @@ source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@0.7.3, source-map@^0.7.2:
+source-map@0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
-source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7:
+source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
@@ -6582,24 +6347,24 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
-tinacms@^0.13.0:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/tinacms/-/tinacms-0.13.1.tgz#94cc9dec10249f226134803b63d0b6430bcddfc6"
-  integrity sha512-GefrYlCa3Cogv6YomrM4JW/fCBMD/VxjeCrArS/hRPcZxe1gOjKGDeW3Bb1QYOsXVVdsv4eFcH+k1JFYnrKPjw==
+tinacms@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/tinacms/-/tinacms-0.16.0.tgz#14df11ae446bc720b5246b4ce8f0cbd89ee090c3"
+  integrity sha512-88VubFhZo5wJk+uDSb5WUJsWwDaCE1oUcHv0KnZknEinnCVxwl9Z/KEEIVtuGSbLBcoQq4fo6uJuRWOVtwYU3A==
   dependencies:
-    "@tinacms/core" "^0.7.1"
-    "@tinacms/fields" "^0.5.0"
-    "@tinacms/form-builder" "^0.2.15"
-    "@tinacms/forms" "^0.2.0"
-    "@tinacms/icons" "^0.5.2"
-    "@tinacms/react-core" "^0.2.7"
-    "@tinacms/styles" "^0.1.2"
+    "@tinacms/core" "^0.7.2"
+    "@tinacms/fields" "^0.7.0"
+    "@tinacms/form-builder" "^0.2.16"
+    "@tinacms/forms" "^0.2.1"
+    "@tinacms/icons" "^0.7.0"
+    "@tinacms/react-core" "^0.2.8"
+    "@tinacms/styles" "^0.3.0"
     "@types/react-beautiful-dnd" "^11.0.3"
     lodash.clonedeep "^4.5.0"
     lodash.merge "^4.6.2"
     react-beautiful-dnd "^11.0.5"
     react-datetime "^2.16.3"
-    react-dismissible "^1.1.4"
+    react-dismissible "^1.1.5"
 
 tiny-invariant@^1.0.4, tiny-invariant@^1.0.6:
   version "1.0.6"
@@ -6655,13 +6420,6 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
-
-touch@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/touch/-/touch-2.0.2.tgz#ca0b2a3ae3211246a61b16ba9e6cbf1596287164"
-  integrity sha512-qjNtvsFXTRq7IuMLweVgFxmEuQ6gLbRs2jQxL80TtZ31dEKWYIxRXquij6w6VimyDek5hD3PytljHmEtAs2u0A==
-  dependencies:
-    nopt "~1.0.10"
 
 traverse@0.6.6:
   version "0.6.6"
@@ -7164,10 +6922,3 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
-
-yaml@^1.7.2:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.7.2.tgz#f26aabf738590ab61efaca502358e48dc9f348b2"
-  integrity sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==
-  dependencies:
-    "@babel/runtime" "^7.6.3"


### PR DESCRIPTION
## What this does:
- Updates all pages to use helpers from `next-tinacms-json` or `next-tinacms-markdown` packages
- Updates Tina to V 0.13.0. I need to update to the latest but trying to do one step at a time givena ll the breaking changes
- Due to the update the `_app.js` config for passing sidebar options was changed.
- I need to upgrade the git packages but having an issue getting it to work. Making a new PR.